### PR TITLE
Add roads vector tileset, draw tools, and measurement functionality

### DIFF
--- a/db.js
+++ b/db.js
@@ -31,7 +31,8 @@ const mbtilesDb =
     landslide:  openOptional(path.join(__dirname, 'data/landslide_rp20.mbtiles')),
     avalanche:  openOptional(path.join(__dirname, 'data/avalanche_rp100.mbtiles')),
     earthquake: openOptional(path.join(__dirname, 'data/earthquake_rp475.mbtiles')),
-    contours :  openOptional(path.join(__dirname, 'data/contours_100m.mbtiles'))
+    contours :  openOptional(path.join(__dirname, 'data/contours_100m.mbtiles')),
+    roads:      openOptional(path.join(__dirname, 'data/main_afg_roads.mbtiles')) // open roads with write access for caching
 };
 
 module.exports = { db, mbtilesDb, analyticsDb }; 

--- a/public/context-config.json
+++ b/public/context-config.json
@@ -18,22 +18,21 @@
     "maxZoom": 14
   },
   {
-    "id": "contours",
-    "name": "Contours - 100m",
-    "type": "tiles",
-    "url": "/tiles/contours/{z}/{x}/{y}.pbf",
-    "default": false,
-    "minZoom": 12,
-    "maxNativeZoom": 15,
-    "maxZoom": 18
-  },
-  {
     "id": "roads",
     "name": "Roads",
     "url": "/tiles/roads/{z}/{x}/{y}.pbf",
     "default": false,
-    "minZoom": 10,
+    "minZoom": 6,
     "maxNativeZoom":16,
+    "maxZoom": 18
+  },
+  {
+    "id": "contours",
+    "name": "Contours - 100m",
+    "url": "/tiles/contours/{z}/{x}/{y}.pbf",
+    "default": false,
+    "minZoom": 12,
+    "maxNativeZoom": 15,
     "maxZoom": 18
   }
 ]

--- a/public/context-config.json
+++ b/public/context-config.json
@@ -26,5 +26,13 @@
     "minZoom": 12,
     "maxNativeZoom": 15,
     "maxZoom": 18
+  },
+  {
+    "id": "roads",
+    "name": "Roads",
+    "url": "/api/roads",
+    "default": false,
+    "minZoom": 12,
+    "maxZoom": 18
   }
 ]

--- a/public/context-config.json
+++ b/public/context-config.json
@@ -30,9 +30,10 @@
   {
     "id": "roads",
     "name": "Roads",
-    "url": "/api/roads",
+    "url": "/tiles/roads/{z}/{x}/{y}.pbf",
     "default": false,
-    "minZoom": 12,
+    "minZoom": 10,
+    "maxNativeZoom":16,
     "maxZoom": 18
   }
 ]

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -4,9 +4,9 @@
    ================================================================ */
 
 :root {
-    --wb-blue:     #009FDA;
-    --wb-navy:     #002244;
-    --wb-gray-50:  #F7F8FA;
+    --wb-blue: #009FDA;
+    --wb-navy: #002244;
+    --wb-gray-50: #F7F8FA;
     --wb-gray-100: #EEF0F3;
     --wb-gray-500: #6B7280;
     --wb-gray-900: #111827;
@@ -16,7 +16,8 @@
 }
 
 /* ── RESET & BASE ── */
-html, body {
+html,
+body {
     margin: 0;
     padding: 0;
     height: 100%;
@@ -60,11 +61,16 @@ body {
     font-family: 'Open Sans', Arial, sans-serif;
 }
 
-button, input, select, textarea {
+button,
+input,
+select,
+textarea {
     font-family: inherit;
 }
 
-button { cursor: pointer; }
+button {
+    cursor: pointer;
+}
 
 /* ── FOCUS ACCESSIBILITY ── */
 *:focus-visible {
@@ -131,10 +137,22 @@ button { cursor: pointer; }
 }
 
 /* Sidebar scrollbar — visible enough to hint scrollability */
-#sidebar::-webkit-scrollbar { width: 5px; }
-#sidebar::-webkit-scrollbar-track { background: rgba(255,255,255,0.05); }
-#sidebar::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.35); border-radius: 2px; }
-#sidebar::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.55); }
+#sidebar::-webkit-scrollbar {
+    width: 5px;
+}
+
+#sidebar::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+#sidebar::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.35);
+    border-radius: 2px;
+}
+
+#sidebar::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.55);
+}
 
 /* ── SIDEBAR SECTIONS ── */
 .sidebar-section {
@@ -428,7 +446,7 @@ button { cursor: pointer; }
     width: 100%;
     height: 4px;
     border-radius: 2px;
-    background: linear-gradient(to right, var(--wb-blue), rgba(255,255,255,0.2));
+    background: linear-gradient(to right, var(--wb-blue), rgba(255, 255, 255, 0.2));
     outline: none;
     cursor: pointer;
 }
@@ -442,11 +460,13 @@ button { cursor: pointer; }
     background: white;
     border: 2px solid var(--wb-blue);
     cursor: pointer;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     transition: transform 0.1s ease;
 }
 
-#opacity-range::-webkit-slider-thumb:hover { transform: scale(1.2); }
+#opacity-range::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+}
 
 #opacity-range::-moz-range-thumb {
     height: 14px;
@@ -624,8 +644,13 @@ button { cursor: pointer; }
     transition: background 0.15s ease, transform 0.1s ease;
 }
 
-.export-btn:hover { background: #007fb5; }
-.export-btn:active { transform: scale(0.98); }
+.export-btn:hover {
+    background: #007fb5;
+}
+
+.export-btn:active {
+    transform: scale(0.98);
+}
 
 .export-btn:disabled {
     background: rgba(0, 159, 218, 0.4);
@@ -699,7 +724,7 @@ button { cursor: pointer; }
     width: 14px;
     height: 14px;
     border-radius: 2px;
-    border: 1px solid rgba(0,0,0,0.1);
+    border: 1px solid rgba(0, 0, 0, 0.1);
     flex-shrink: 0;
 }
 
@@ -732,9 +757,9 @@ button { cursor: pointer; }
     margin: 0;
     text-shadow:
         -1px -1px 0 #fff, 1px -1px 0 #fff,
-        -1px  1px 0 #fff, 1px  1px 0 #fff,
+        -1px 1px 0 #fff, 1px 1px 0 #fff,
         -2px 0 0 #fff, 2px 0 0 #fff,
-        0 -2px 0 #fff, 0  2px 0 #fff;
+        0 -2px 0 #fff, 0 2px 0 #fff;
 }
 
 /* ── LOADING OVERLAY ── */
@@ -762,7 +787,11 @@ button { cursor: pointer; }
     animation: spin 0.9s linear infinite;
 }
 
-@keyframes spin { 100% { transform: rotate(360deg); } }
+@keyframes spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
 
 .loading-text {
     margin-top: 12px;
@@ -812,23 +841,27 @@ button { cursor: pointer; }
     border: none;
     border-radius: 4px;
     cursor: pointer;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
     transition: background 0.15s ease;
 }
 
 .close-btn {
     background: rgba(30, 30, 30, 0.85);
-    border: 1px solid rgba(255,255,255,0.2);
+    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-.close-btn:hover { background: #dc3545; }
+.close-btn:hover {
+    background: #dc3545;
+}
 
 .download-from-preview-btn {
     background: var(--wb-blue);
     border: none;
 }
 
-.download-from-preview-btn:hover { background: #007fb5; }
+.download-from-preview-btn:hover {
+    background: #007fb5;
+}
 
 #pdf-content {
     width: 297mm;
@@ -843,7 +876,8 @@ button { cursor: pointer; }
     border-right: #fff 2px solid;
 }
 
-#wb-logo, #pdf-hazard-icon {
+#wb-logo,
+#pdf-hazard-icon {
     width: 36px;
     height: 36px;
     object-fit: contain;
@@ -853,7 +887,7 @@ button { cursor: pointer; }
     padding-right: 10px;
 }
 
-#wb-logo{
+#wb-logo {
     border-right: none;
     border-left: #fff solid 1px;
     padding-left: 10px;
@@ -869,7 +903,7 @@ button { cursor: pointer; }
     align-items: center;
 }
 
-#pdf-map-title{
+#pdf-map-title {
     margin-top: 0;
     margin-bottom: 0;
     color: white;
@@ -987,7 +1021,9 @@ button { cursor: pointer; }
     display: none;
 }
 
-.legend-label { font-size: 13px; }
+.legend-label {
+    font-size: 13px;
+}
 
 .legend-gradient-bar {
     width: 24px;
@@ -1013,7 +1049,7 @@ button { cursor: pointer; }
     height: 90%;
     position: relative;
     resize: none;
-} 
+}
 
 #pdf-description-label,
 #hazard-legend-title,
@@ -1030,8 +1066,15 @@ button { cursor: pointer; }
     font-size: 9px;
 }
 
-#footer-text { margin: 1px; font-style: italic; }
-#footer-date, #footer-contact { margin: 1px; }
+#footer-text {
+    margin: 1px;
+    font-style: italic;
+}
+
+#footer-date,
+#footer-contact {
+    margin: 1px;
+}
 
 #footer-column-2 {
     flex: 0 0 250px;
@@ -1071,13 +1114,41 @@ button { cursor: pointer; }
 
 .leaflet-left {
     display: flex;
-    flex-direction: row;  /* change from column to row */
+    flex-direction: column;
+    /* change from column to row */
     align-items: center;
 }
 
-div.leaflet-top.leaflet-left {
-    flex-direction: column;;
+/* div.leaflet-top.leaflet-left {
+    flex-direction: column;
+    align-items: center ;
+} */
+
+
+.draw-toggle {
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    margin-left: 10px;
+    margin-top: 10px;
+    text-align: center;
+    font-size: 16px;
+    display: flex;
+    text-decoration: none;
+    background: white;
+    color: black;
+    position: relative;
+    z-index: 10000;
+    pointer-events: auto;
+    filter: grayscale(100%);
+    border-radius:2px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
 }
+
+#draw-toggle:hover {
+    background-color: var(--wb-gray-100);
+}
+
 
 /* .custom-scale-text {
     font-size: 12px;
@@ -1092,21 +1163,20 @@ div.leaflet-top.leaflet-left {
     border: 2px solid var(--wb-navy);
 
     background: linear-gradient(to right,
-        var(--wb-navy) 0%,
-        var(--wb-navy) 20%,
+            var(--wb-navy) 0%,
+            var(--wb-navy) 20%,
 
-        #fff 20%,
-        #fff 40%,
+            #fff 20%,
+            #fff 40%,
 
-        var(--wb-navy) 40%,
-        var(--wb-navy) 60%,
+            var(--wb-navy) 40%,
+            var(--wb-navy) 60%,
 
-        #fff 60%,
-        #fff 80%,
+            #fff 60%,
+            #fff 80%,
 
-        var(--wb-navy) 80%,
-        var(--wb-navy) 100%
-    );
+            var(--wb-navy) 80%,
+            var(--wb-navy) 100%);
 }
 
 .custom-scale-labels {
@@ -1142,10 +1212,12 @@ div.leaflet-top.leaflet-left {
     margin-left: 6px;
     transform: none;
 }
+
 /* ================================================================
    PRINT CSS
    ================================================================ */
 @media print {
+
     #sidebar,
     #app-header,
     #pdf-wrapper,

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1075,6 +1075,10 @@ button { cursor: pointer; }
     align-items: center;
 }
 
+div.leaflet-top.leaflet-left {
+    flex-direction: column;;
+}
+
 /* .custom-scale-text {
     font-size: 12px;
     font-weight: 600;

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -21,6 +21,7 @@ let baseMaps = {};
 let scaleBarText, scaleBarWidth, scaleBarStops, scaleBarLabels, scaleBarUnit, leafletScaleBarElement, scaleBarTextElement;
 let currentHazardDescription = '';
 let leafletBottomLeft;
+let fetchUrl;
 
 
 const provSelect = document.getElementById('prov-select');
@@ -181,22 +182,33 @@ function buildContextToggle(container, layerConfig) {
     row.appendChild(label);
     container.appendChild(row);
 
-    // If default=true, load immediately
+    // Update zoom note on map zoom
+    map.on('zoomend', () => updateZoomNote(row, layerConfig));
+    updateZoomNote(row, layerConfig);
+
+    // If default=true, load immediately (but only if above minZoom)
     if (layerConfig.default) {
-        fetchAndAddContextLayer(layerConfig, checkbox, row);
+        const currentZoom = map.getZoom();
+        if (!layerConfig.minZoom || currentZoom >= layerConfig.minZoom) {
+            fetchAndAddContextLayer(layerConfig, checkbox, row);
+        } else {
+            checkbox.checked = false;
+        }
     }
 
     checkbox.addEventListener('change', function () {
+        // Check zoom level before allowing layer activation
+        const currentZoom = map.getZoom();
         if (this.checked) {
+            if (layerConfig.minZoom && currentZoom < layerConfig.minZoom) {
+                this.checked = false;
+                return;
+            }
             fetchAndAddContextLayer(layerConfig, checkbox, row);
         } else {
             removeContextLayer(layerConfig.id);
         }
     });
-
-    // Update zoom note on map zoom
-    map.on('zoomend', () => updateZoomNote(row, layerConfig));
-    updateZoomNote(row, layerConfig);
 }
 
 function fetchAndAddContextLayer(layerConfig, checkbox, row) {
@@ -228,6 +240,148 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
             }
         }
         updateZoomNote(row, layerConfig);
+        return;
+    }
+
+    if (layerConfig.id === 'roads') {
+        // Function to style roads based on road_class
+        function getRoadStyle(feature) {
+            const roadClass = (feature.properties?.class || '').toLowerCase();
+
+            const styleMap = {
+                'primary': { color: '#FF6B35', weight: 3, opacity: 0.9 },
+                'secondary': { color: '#FFD93D', weight: 2, opacity: 0.85 },
+                'tertiary': { color: '#FFD93D', weight: 2, opacity: 0.85 }
+            };
+
+            const defaultStyle = { color: '#E0E0E0', weight: 1.5, opacity: 0.7 };
+
+            return styleMap[roadClass] || defaultStyle;
+        }
+
+        // Function to fetch and update roads data
+        function updateRoadsData() {
+            const bounds = map.getBounds();
+            const sw = bounds.getSouthWest();
+            const ne = bounds.getNorthEast();
+            const params = new URLSearchParams({
+                xmin: sw.lng,
+                xmax: ne.lng,
+                ymin: sw.lat,
+                ymax: ne.lat
+            });
+            const fetchUrl = `${layerConfig.url}?${params}`;
+
+            fetch(fetchUrl)
+                .then(res => {
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                    return res.json();
+                })
+                .then(data => {
+                    const roadsLayer = contextLayerInstances[layerConfig.id];
+                    if (!roadsLayer || !map.hasLayer(roadsLayer)) return;
+
+                    // Clear existing features
+                    roadsLayer.clearLayers();
+
+                    // Add new features
+                    data.features.forEach(feature => {
+                        const layer = L.geoJSON(feature, {
+                            style: getRoadStyle,
+                            onEachFeature: function (feat, l) {
+                                const roadName = feat.properties?.name || '';
+                                if (l.setText) {
+                                    l.setText(roadName, {
+                                        repeat: false,
+                                        center: true,
+                                        orientation: 'auto',
+                                        offset: 0,
+                                        attributes: {
+                                            fill: 'black',
+                                            stroke: 'white',
+                                            'stroke-width': 3,
+                                            'paint-order': 'stroke',
+                                            'font-weight': 'bold',
+                                            'font-size': '12px'
+                                        }
+                                    });
+                                }
+                            }
+                        });
+                        roadsLayer.addLayer(layer);
+                    });
+                })
+                .catch(err => console.error('Roads update failed:', err));
+        }
+
+        // Initial fetch
+        const bounds = map.getBounds();
+        const sw = bounds.getSouthWest();
+        const ne = bounds.getNorthEast();
+        const params = new URLSearchParams({
+            xmin: sw.lng,
+            xmax: ne.lng,
+            ymin: sw.lat,
+            ymax: ne.lat
+        });
+        const fetchUrl = `${layerConfig.url}?${params}`;
+
+        fetch(fetchUrl)
+            .then(res => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then(data => {
+                if (data.features.length > 0) {
+                    console.log('First feature:', data.features[0]);
+                }
+                loadingNote.remove();
+                checkbox.disabled = false;
+
+                const roadsLayer = L.geoJSON(data, {
+                    style: getRoadStyle,
+                    onEachFeature: function (feature, layer) {
+                        const roadName = feature.properties?.name || '';
+
+                        // Apply text along the polyline
+                        if (layer.setText) { // Provided by leaflet-textpath
+                            layer.setText(roadName, {
+                                repeat: false,      // label appears once
+                                center: true,       // centered along the line
+                                orientation: 'auto', // rotates along the line
+                                offset: 0,
+                                attributes: {
+                                    fill: 'black',          // inner text color
+                                    stroke: 'white',        // halo color
+                                    'stroke-width': 3,      // halo thickness
+                                    'paint-order': 'stroke', // ensures stroke is drawn behind text
+                                    'font-weight': 'bold',
+                                    'font-size': '12px'
+                                }
+
+                            });
+                        }
+                    }
+                });
+                contextLayerInstances[layerConfig.id] = roadsLayer;
+                if (checkbox.checked) {
+                    roadsLayer.addTo(map);
+                    // Attach moveend listener when layer is added
+                    roadsLayer._moveendHandler = updateRoadsData;
+                    map.on('moveend', updateRoadsData);
+                }
+                overlayLayers[layerConfig.name] = roadsLayer;
+                updateZoomNote(row, layerConfig);
+            })
+            .catch(() => {
+                loadingNote.remove();
+                checkbox.disabled = false;
+                checkbox.checked = false;
+                const errNote = document.createElement('p');
+                errNote.className = 'context-unavailable';
+                errNote.textContent = `${layerConfig.name} unavailable`;
+                row.appendChild(errNote);
+            });
         return;
     }
 
@@ -321,6 +475,10 @@ function removeContextLayer(id) {
     const layer = contextLayerInstances[id];
     if (layer && map.hasLayer(layer)) {
         map.removeLayer(layer);
+        // Clean up moveend listener for roads layer
+        if (id === 'roads' && layer._moveendHandler) {
+            map.off('moveend', layer._moveendHandler);
+        }
     }
 }
 
@@ -328,7 +486,18 @@ function updateZoomNote(row, layerConfig) {
     if (!map) return;
     const existingNote = row.querySelector('.context-zoom-note:not(.context-loading)');
     const currentZoom = map.getZoom();
+    const checkbox = row.querySelector('input[type="checkbox"]');
+
     if (layerConfig.minZoom && currentZoom < layerConfig.minZoom) {
+        // Below minZoom: disable checkbox, show note
+        if (checkbox) {
+            checkbox.disabled = true;
+            // If layer is checked and we've zoomed below minZoom, remove it
+            if (checkbox.checked) {
+                checkbox.checked = false;
+                removeContextLayer(layerConfig.id);
+            }
+        }
         if (!existingNote) {
             const note = document.createElement('p');
             note.className = 'context-zoom-note';
@@ -336,6 +505,10 @@ function updateZoomNote(row, layerConfig) {
             row.appendChild(note);
         }
     } else {
+        // At or above minZoom: enable checkbox, remove note
+        if (checkbox) {
+            checkbox.disabled = false;
+        }
         if (existingNote) existingNote.remove();
     }
 }

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -129,42 +129,85 @@ function initMap() {
 
     setupScaleBarText();
 
+    let drawToggleContainer = L.DomUtil.create('div', 'leaflet-bar');
+    drawToggleContainer.style.border = 'none';
+    let drawToggleBtn = L.DomUtil.create('a', 'draw-toggle', drawToggleContainer);
+    drawToggleBtn.innerHTML = '✏️';
+
+    drawToggleBtn.href = '#';
+    drawToggleBtn.type = 'button';
+    drawToggleBtn.title = 'Draw Tools';
+
+    document.querySelector('.leaflet-top.leaflet-left').appendChild(drawToggleContainer);
+
+
     // feature group to store the draw items
     var drawItems = new L.FeatureGroup();
     map.addLayer(drawItems);
 
     // draw controls
     var drawControl = new L.Control.Draw({
-        edit: {featureGroup:drawItems},
+        edit: { featureGroup: drawItems },
         draw: {
             // polygon: true,
-            polyline: true,
+            // polyline: true,
             // circle: true,
             // rectangle: true,
+            circlemarker: false
         }
 
     });
     map.addControl(drawControl);
 
+    setTimeout(() => {
+        const el = document.querySelector('.leaflet-draw.leaflet-control');
+        if (el) el.style.display = 'none';
+    }, 0);
+
+    let visible = false;
+    drawToggleBtn.onclick = function (e) {
+        e.preventDefault();
+        const drawControl = document.querySelector('.leaflet-draw.leaflet-control');
+        if (!drawControl) return;
+        visible = !visible;
+        drawControl.style.display = visible ? 'block' : 'none';
+    };
+
     //handle draw events
 
-    map.on('draw:created', function(e) {
+    map.on('draw:created', function (e) {
         const layer = e.layer;
         drawItems.addLayer(layer);
 
         const geojson = layer.toGeoJSON();
+        console.log(geojson);
         let result = "";
 
         if (geojson.geometry.type === 'LineString') {
-            const length = turf.length(geojson, {units: 'kilometers'});
+            const length = turf.length(geojson, { units: 'kilometers' });
             result = `Distance: ${length.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km`;
         }
 
-        if (geojson.geometry.type === 'Polygon') {
+        else if (geojson.geometry.type === 'Polygon') {
             const area = turf.area(geojson);
             const sqkm = area / 1000000;
             result = `Area: ${sqkm.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km²`;
         }
+
+        else if (layer instanceof L.Circle) {
+            const center = layer.getLatLng();
+            const radiusMeters = layer.getRadius();
+            const radiusKm = radiusMeters / 1000;
+
+            result = `Center: ${center.lat.toFixed(6)}, ${center.lng.toFixed(6)}<br>
+                  Radius: ${radiusKm.toFixed(2)} km`;
+        }
+
+        else if (geojson.geometry.type === 'Point') {
+            const [lng, lat] = geojson.geometry.coordinates;
+            result = `Lat: ${lat.toFixed(6)}, <br> Lon: ${lng.toFixed(6)}`;
+        }
+
 
         layer.bindPopup(result).openPopup();
     });
@@ -1079,7 +1122,7 @@ function resetLegend() {
 // ----------------------
 function createPdfLayout(download = true) {
     const mapElement = document.getElementById('map');
-    const zoomControl = document.querySelector(".leaflet-control-zoom");
+    const topLeftControl = document.querySelector("div.leaflet-top.leaflet-left");
     const mapContainerLayout = document.getElementById('map-container');
     const scaleBarLayout = document.getElementById('scale-bar');
     const today = new Date();
@@ -1100,7 +1143,7 @@ function createPdfLayout(download = true) {
     buildLegend(activeAdminLayers);
 
     // Hide zoom and scale controls for clean screenshot
-    if (zoomControl) zoomControl.style.display = 'none';
+    if (topLeftControl) topLeftControl.style.display = 'none';
     if (leafletScaleBarElement) leafletScaleBarElement.style.display = 'none';
 
     // Temporarily resize map to exact PDF dimensions (230mm × 170mm at 96dpi)
@@ -1123,7 +1166,7 @@ function createPdfLayout(download = true) {
             mapElement.style.flex = origFlex;
             map.invalidateSize({ animate: false });
 
-            if (zoomControl) zoomControl.style.display = '';
+            if (topLeftControl) topLeftControl.style.display = '';
             if (leafletScaleBarElement) leafletScaleBarElement.style.display = '';
 
             const mapImg = new Image();
@@ -1224,7 +1267,7 @@ function createPdfLayout(download = true) {
             mapElement.style.height = origHeight;
             mapElement.style.flex = origFlex;
             map.invalidateSize({ animate: false });
-            if (zoomControl) zoomControl.style.display = '';
+            if (topLeftControl) topLeftControl.style.display = '';
             if (leafletScaleBarElement) leafletScaleBarElement.style.display = '';
             console.error('PDF capture failed:', err);
         });

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -270,8 +270,9 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
                 ymin: sw.lat,
                 ymax: ne.lat
             });
+            // console.log(params);
             const fetchUrl = `${layerConfig.url}?${params}`;
-
+            // console.log('Fetching roads data with URL:', fetchUrl);
             fetch(fetchUrl)
                 .then(res => {
                     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -288,25 +289,25 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
                     data.features.forEach(feature => {
                         const layer = L.geoJSON(feature, {
                             style: getRoadStyle,
-                            onEachFeature: function (feat, l) {
-                                const roadName = feat.properties?.name || '';
-                                if (l.setText) {
-                                    l.setText(roadName, {
-                                        repeat: false,
-                                        center: true,
-                                        orientation: 'auto',
-                                        offset: 0,
-                                        attributes: {
-                                            fill: 'black',
-                                            stroke: 'white',
-                                            'stroke-width': 3,
-                                            'paint-order': 'stroke',
-                                            'font-weight': 'bold',
-                                            'font-size': '12px'
-                                        }
-                                    });
-                                }
-                            }
+                            // onEachFeature: function (feat, l) {
+                            //     const roadName = feat.properties?.name || '';
+                            //     if (l.setText) {
+                            //         l.setText(roadName, {
+                            //             repeat: false,
+                            //             center: true,
+                            //             orientation: 'auto',
+                            //             offset: 0,
+                            //             attributes: {
+                            //                 fill: 'black',
+                            //                 stroke: 'white',
+                            //                 'stroke-width': 3,
+                            //                 'paint-order': 'stroke',
+                            //                 'font-weight': 'bold',
+                            //                 'font-size': '12px'
+                            //             }
+                            //         });
+                            //     }
+                            // }
                         });
                         roadsLayer.addLayer(layer);
                     });
@@ -332,36 +333,32 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
                 return res.json();
             })
             .then(data => {
-                if (data.features.length > 0) {
-                    console.log('First feature:', data.features[0]);
-                }
                 loadingNote.remove();
                 checkbox.disabled = false;
 
                 const roadsLayer = L.geoJSON(data, {
                     style: getRoadStyle,
-                    onEachFeature: function (feature, layer) {
-                        const roadName = feature.properties?.name || '';
+                    // onEachFeature: function (feature, layer) {
+                    //     const roadName = feature.properties?.name || '';
+                    //     // Apply text along the polyline
+                    //     if (layer.setText) { // Provided by leaflet-textpath
+                    //         layer.setText(roadName, {
+                    //             repeat: false,      // label appears once
+                    //             center: true,       // centered along the line
+                    //             orientation: 'auto', // rotates along the line
+                    //             offset: 0,
+                    //             attributes: {
+                    //                 fill: 'black',          // inner text color
+                    //                 stroke: 'white',        // halo color
+                    //                 'stroke-width': 3,      // halo thickness
+                    //                 'paint-order': 'stroke', // ensures stroke is drawn behind text
+                    //                 'font-weight': 'bold',
+                    //                 'font-size': '12px'
+                    //             }
 
-                        // Apply text along the polyline
-                        if (layer.setText) { // Provided by leaflet-textpath
-                            layer.setText(roadName, {
-                                repeat: false,      // label appears once
-                                center: true,       // centered along the line
-                                orientation: 'auto', // rotates along the line
-                                offset: 0,
-                                attributes: {
-                                    fill: 'black',          // inner text color
-                                    stroke: 'white',        // halo color
-                                    'stroke-width': 3,      // halo thickness
-                                    'paint-order': 'stroke', // ensures stroke is drawn behind text
-                                    'font-weight': 'bold',
-                                    'font-size': '12px'
-                                }
-
-                            });
-                        }
-                    }
+                    //         });
+                    //     }
+                    // }
                 });
                 contextLayerInstances[layerConfig.id] = roadsLayer;
                 if (checkbox.checked) {

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -21,8 +21,6 @@ let baseMaps = {};
 let scaleBarText, scaleBarWidth, scaleBarStops, scaleBarLabels, scaleBarUnit, leafletScaleBarElement, scaleBarTextElement;
 let currentHazardDescription = '';
 let leafletBottomLeft;
-let fetchUrl;
-
 
 const provSelect = document.getElementById('prov-select');
 const distSelect = document.getElementById('dist-select');
@@ -87,14 +85,18 @@ function initMap() {
         'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: 'Tiles &copy; Esri',
         crossOrigin: true,
-        zIndex: 1
+        zIndex: 1,
+        updateWhenIdle: true,
+        keepBuffer: 5
     });
 
     baseMaps['OpenStreetMap'] = L.tileLayer(
         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; OpenStreetMap contributors',
         crossOrigin: true,
-        zIndex: 1
+        zIndex: 1,
+        updateWhenIdle: true,
+        keepBuffer: 5
     });
 
     baseMaps['Esri Satellite'].addTo(map);
@@ -245,32 +247,37 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
 
     if (layerConfig.id === 'roads') {
         function getRoadStyle(properties) {
-            // console.log('getRoadStyle called with:', properties);
             // Handle both feature objects and property objects
             const props = properties.properties || properties;
-            
-            const roadClass = (props.road_class || props.class || props.type || props.highway || '').toLowerCase();
 
-            if (roadClass.includes('primary')) {
+            const roadClass = (props.road_class || '').toLowerCase();
+            // console.log(roadClass, typeof(roadClass));
+
+            if (roadClass === 'primary') {
                 return { color: '#FF6B35', weight: 3, opacity: 0.9 };
-            } else if (roadClass.includes('secondary') || roadClass.includes('tertiary')) {
+            } else if (roadClass === 'secondary' || roadClass === 'tertiary') {
                 return { color: '#FFD93D', weight: 2, opacity: 0.85 };
             } else {
                 return { color: '#E0E0E0', weight: 1.5, opacity: 0.7 };
             }
         }
 
+        let zoom = map.getZoom();
+        console.log("Zoom", zoom);
+
         const roadsLayer = L.vectorGrid.protobuf(layerConfig.url,
             {
                 minZoom: layerConfig.minZoom,
                 maxNativeZoom: layerConfig.maxNativeZoom,
                 maxZoom: layerConfig.maxZoom,
+                updateWhenIdle: true,
                 vectorTileLayerStyles: {
-                    main_afg_roads_4326: getRoadStyle
+                    main_afg_roads: getRoadStyle
                 },
                 interactive: true,
             }
         );
+
         contextLayerInstances[layerConfig.id] = roadsLayer;
         overlayLayers[layerConfig.name] = roadsLayer;
 
@@ -292,7 +299,7 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
         });
 
         updateZoomNote(row, layerConfig);
-        return;
+        // return;
     }
 
 
@@ -347,7 +354,7 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
                 row.appendChild(errNote);
             });
     }
-    else if (layerConfig.type === 'tiles') {
+    else if (layerConfig.id === 'contours') {
         loadingNote.remove();
         checkbox.disabled = false;
         contourLayer = L.vectorGrid.protobuf(layerConfig.url, {
@@ -358,29 +365,31 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
                 contours: { weight: 0.5, color: '#080808' }
             }
         });
+
+
         contextLayerInstances[layerConfig.id] = contourLayer;
-        if (checkbox.checked) {
-            contourLayer.addTo(map);
-        }
         overlayLayers[layerConfig.name] = contourLayer;
+
+        // Remove loading note and enable checkbox
+        loadingNote.remove();
+        checkbox.disabled = false;
+
+        
+        if (checkbox.checked) {
+            contourLayer.addTo(map
+
+            );
+        }
+
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                contourLayer.addTo(map);
+            } else {
+                map.removeLayer(contourLayer);
+            }
+        });
         updateZoomNote(row, layerConfig);
     }
-    // else if (layerConfig.type === 'raster') {
-    //     loadingNote.remove();
-    //     checkbox.disabled = false;
-    //     const rasterLayer = L.tileLayer(layerConfig.url, {
-    //         minZoom: layerConfig.minZoom || 1,
-    //         maxZoom: layerConfig.maxZoom || 18,
-    //         opacity: 0.7,
-    //         zIndex: 150
-    //     });
-    //     contextLayerInstances[layerConfig.id] = rasterLayer;
-    //     if (checkbox.checked) {
-    //         rasterLayer.addTo(map);
-    //     }
-    //     overlayLayers[layerConfig.name] = rasterLayer;
-    //     updateZoomNote(row, layerConfig);
-    // }
 }
 
 function removeContextLayer(id) {

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -129,6 +129,46 @@ function initMap() {
 
     setupScaleBarText();
 
+    // feature group to store the draw items
+    var drawItems = new L.FeatureGroup();
+    map.addLayer(drawItems);
+
+    // draw controls
+    var drawControl = new L.Control.Draw({
+        edit: {featureGroup:drawItems},
+        draw: {
+            // polygon: true,
+            polyline: true,
+            // circle: true,
+            // rectangle: true,
+        }
+
+    });
+    map.addControl(drawControl);
+
+    //handle draw events
+
+    map.on('draw:created', function(e) {
+        const layer = e.layer;
+        drawItems.addLayer(layer);
+
+        const geojson = layer.toGeoJSON();
+        let result = "";
+
+        if (geojson.geometry.type === 'LineString') {
+            const length = turf.length(geojson, {units: 'kilometers'});
+            result = `Distance: ${length.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km`;
+        }
+
+        if (geojson.geometry.type === 'Polygon') {
+            const area = turf.area(geojson);
+            const sqkm = area / 1000000;
+            result = `Area: ${sqkm.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} km²`;
+        }
+
+        layer.bindPopup(result).openPopup();
+    });
+
     getProvinces(0, () => {
         overlay.style.display = 'none';
         enableMapInteraction();

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -244,143 +244,58 @@ function fetchAndAddContextLayer(layerConfig, checkbox, row) {
     }
 
     if (layerConfig.id === 'roads') {
-        // Function to style roads based on road_class
-        function getRoadStyle(feature) {
-            const roadClass = (feature.properties?.class || '').toLowerCase();
+        function getRoadStyle(properties) {
+            // console.log('getRoadStyle called with:', properties);
+            // Handle both feature objects and property objects
+            const props = properties.properties || properties;
+            
+            const roadClass = (props.road_class || props.class || props.type || props.highway || '').toLowerCase();
 
-            const styleMap = {
-                'primary': { color: '#FF6B35', weight: 3, opacity: 0.9 },
-                'secondary': { color: '#FFD93D', weight: 2, opacity: 0.85 },
-                'tertiary': { color: '#FFD93D', weight: 2, opacity: 0.85 }
-            };
-
-            const defaultStyle = { color: '#E0E0E0', weight: 1.5, opacity: 0.7 };
-
-            return styleMap[roadClass] || defaultStyle;
+            if (roadClass.includes('primary')) {
+                return { color: '#FF6B35', weight: 3, opacity: 0.9 };
+            } else if (roadClass.includes('secondary') || roadClass.includes('tertiary')) {
+                return { color: '#FFD93D', weight: 2, opacity: 0.85 };
+            } else {
+                return { color: '#E0E0E0', weight: 1.5, opacity: 0.7 };
+            }
         }
 
-        // Function to fetch and update roads data
-        function updateRoadsData() {
-            const bounds = map.getBounds();
-            const sw = bounds.getSouthWest();
-            const ne = bounds.getNorthEast();
-            const params = new URLSearchParams({
-                xmin: sw.lng,
-                xmax: ne.lng,
-                ymin: sw.lat,
-                ymax: ne.lat
-            });
-            // console.log(params);
-            const fetchUrl = `${layerConfig.url}?${params}`;
-            // console.log('Fetching roads data with URL:', fetchUrl);
-            fetch(fetchUrl)
-                .then(res => {
-                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-                    return res.json();
-                })
-                .then(data => {
-                    const roadsLayer = contextLayerInstances[layerConfig.id];
-                    if (!roadsLayer || !map.hasLayer(roadsLayer)) return;
+        const roadsLayer = L.vectorGrid.protobuf(layerConfig.url,
+            {
+                minZoom: layerConfig.minZoom,
+                maxNativeZoom: layerConfig.maxNativeZoom,
+                maxZoom: layerConfig.maxZoom,
+                vectorTileLayerStyles: {
+                    main_afg_roads_4326: getRoadStyle
+                },
+                interactive: true,
+            }
+        );
+        contextLayerInstances[layerConfig.id] = roadsLayer;
+        overlayLayers[layerConfig.name] = roadsLayer;
 
-                    // Clear existing features
-                    roadsLayer.clearLayers();
+        // Remove loading note and enable checkbox
+        loadingNote.remove();
+        checkbox.disabled = false;
 
-                    // Add new features
-                    data.features.forEach(feature => {
-                        const layer = L.geoJSON(feature, {
-                            style: getRoadStyle,
-                            // onEachFeature: function (feat, l) {
-                            //     const roadName = feat.properties?.name || '';
-                            //     if (l.setText) {
-                            //         l.setText(roadName, {
-                            //             repeat: false,
-                            //             center: true,
-                            //             orientation: 'auto',
-                            //             offset: 0,
-                            //             attributes: {
-                            //                 fill: 'black',
-                            //                 stroke: 'white',
-                            //                 'stroke-width': 3,
-                            //                 'paint-order': 'stroke',
-                            //                 'font-weight': 'bold',
-                            //                 'font-size': '12px'
-                            //             }
-                            //         });
-                            //     }
-                            // }
-                        });
-                        roadsLayer.addLayer(layer);
-                    });
-                })
-                .catch(err => console.error('Roads update failed:', err));
+        // Add layer to map if checkbox is already checked
+        if (checkbox.checked) {
+            roadsLayer.addTo(map);
         }
 
-        // Initial fetch
-        const bounds = map.getBounds();
-        const sw = bounds.getSouthWest();
-        const ne = bounds.getNorthEast();
-        const params = new URLSearchParams({
-            xmin: sw.lng,
-            xmax: ne.lng,
-            ymin: sw.lat,
-            ymax: ne.lat
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                roadsLayer.addTo(map);
+            } else {
+                map.removeLayer(roadsLayer);
+            }
         });
-        const fetchUrl = `${layerConfig.url}?${params}`;
 
-        fetch(fetchUrl)
-            .then(res => {
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
-                return res.json();
-            })
-            .then(data => {
-                loadingNote.remove();
-                checkbox.disabled = false;
-
-                const roadsLayer = L.geoJSON(data, {
-                    style: getRoadStyle,
-                    // onEachFeature: function (feature, layer) {
-                    //     const roadName = feature.properties?.name || '';
-                    //     // Apply text along the polyline
-                    //     if (layer.setText) { // Provided by leaflet-textpath
-                    //         layer.setText(roadName, {
-                    //             repeat: false,      // label appears once
-                    //             center: true,       // centered along the line
-                    //             orientation: 'auto', // rotates along the line
-                    //             offset: 0,
-                    //             attributes: {
-                    //                 fill: 'black',          // inner text color
-                    //                 stroke: 'white',        // halo color
-                    //                 'stroke-width': 3,      // halo thickness
-                    //                 'paint-order': 'stroke', // ensures stroke is drawn behind text
-                    //                 'font-weight': 'bold',
-                    //                 'font-size': '12px'
-                    //             }
-
-                    //         });
-                    //     }
-                    // }
-                });
-                contextLayerInstances[layerConfig.id] = roadsLayer;
-                if (checkbox.checked) {
-                    roadsLayer.addTo(map);
-                    // Attach moveend listener when layer is added
-                    roadsLayer._moveendHandler = updateRoadsData;
-                    map.on('moveend', updateRoadsData);
-                }
-                overlayLayers[layerConfig.name] = roadsLayer;
-                updateZoomNote(row, layerConfig);
-            })
-            .catch(() => {
-                loadingNote.remove();
-                checkbox.disabled = false;
-                checkbox.checked = false;
-                const errNote = document.createElement('p');
-                errNote.className = 'context-unavailable';
-                errNote.textContent = `${layerConfig.name} unavailable`;
-                row.appendChild(errNote);
-            });
+        updateZoomNote(row, layerConfig);
         return;
     }
+
+
 
     if (layerConfig.type === 'geojson') {
         fetch(layerConfig.url)
@@ -894,7 +809,7 @@ document.querySelectorAll('input[name="hazard-layer"]')
                 /*if (pdfHazardTitle) {
                     pdfHazardTitle.textContent = '';
                     pdfHazardIcon.style.display = "none";
-
+ 
                 }*/
                 //if (pdfHazardIcon) pdfHazardIcon.src = '';
                 pdfHazardIcon.style.display = "inline-block";

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -354,7 +354,7 @@ router.post('/api/analytics/map-creation', (req, res) => {
             IOM_Code,
             request_type
         );
-        
+
         console.log("Analytics logged with ID:", result.lastInsertRowid);
         res.status(201).json({
             success: true,
@@ -363,6 +363,61 @@ router.post('/api/analytics/map-creation', (req, res) => {
     } catch (err) {
         console.error('Analytics insert error:', err);
         res.status(500).json({ error: 'Failed to save analytics' });
+    }
+});
+
+// API route to fetch roads within a bounding box
+router.get('/api/roads', (req, res) => {
+    const { xmin, xmax, ymin, ymax } = req.query;
+
+    // Validate parameters
+    if (!xmin || !xmax || !ymin || !ymax) {
+        return res.status(400).json({ error: "Missing required parameters: xmin, xmax, ymin, ymax" });
+    }
+
+    try {
+        // Convert to numbers
+        const bbox = {
+            xmin: parseFloat(xmin),
+            xmax: parseFloat(xmax),
+            ymin: parseFloat(ymin),
+            ymax: parseFloat(ymax)
+        };
+
+        // Validate bbox values
+        if (isNaN(bbox.xmin) || isNaN(bbox.xmax) || isNaN(bbox.ymin) || isNaN(bbox.ymax)) {
+            return res.status(400).json({ error: "Invalid bbox values - must be numeric" });
+        }
+
+        const query = `
+            SELECT name, road_class, road_type, geom_to_wkt, minx, miny, maxx, maxy
+            FROM main_afg_roads
+            WHERE
+                minx <= ? AND
+                maxx >= ? AND
+                miny <= ? AND
+                maxy >= ?
+        `;
+
+        const roads = db.prepare(query).all(bbox.xmax, bbox.xmin, bbox.ymax, bbox.ymin);
+        console.log(`Fetched ${roads.length} roads intersecting bbox (${bbox.xmin}, ${bbox.ymin}, ${bbox.xmax}, ${bbox.ymax})`);
+        const geojson = {
+            type: "FeatureCollection",
+            features: roads.map(r => ({
+                type: "Feature",
+                properties: {
+                    name: r.name,
+                    type: r.road_type,
+                    class: r.road_class
+                },
+                geometry: wellknown.parse(r.geom_to_wkt)
+            }))
+        };
+
+        res.json(geojson);
+    } catch (err) {
+        console.error(err);
+        res.status(500).send("Database Error");
     }
 });
 

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -5,6 +5,12 @@ const router = express.Router();
 const wellknown = require('wellknown');
 const { validationResult } = require('express-validator');
 
+const EMPTY_TILE_BUFFER = Buffer.from([
+  0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00
+]);
+
 // Import your custom validators
 const validationParam = require('./validationParams.js'); // Adjust path as necessary
 
@@ -76,6 +82,7 @@ router.get('/tiles/contours/:z/:x/:y.pbf', validationParam.validateVectorTiles, 
 
         res.setHeader('Content-Type', 'application/x-protobuf');
         res.setHeader('Content-Encoding', 'gzip');
+        res.setHeader('Cache-Control', 'public, max-age=1209600'); // Cache for 2 weeks
 
 
         res.send(tile.tile_data);
@@ -382,15 +389,21 @@ router.get('/tiles/roads/:z/:x/:y.pbf', validationParam.validateVectorTiles, (re
         `);
 
         const tile = stmt.get(z, x, flippedY);
-        if (!tile) {
-            return res.status(204).end();
-        }
 
+        
         res.setHeader('Content-Type', 'application/x-protobuf');
         res.setHeader('Content-Encoding', 'gzip');
+<<<<<<< HEAD
+=======
+        res.setHeader('Cache-Control', 'public, max-age=1209600'); // Cache for 2 weeks
+        
+        if (!tile) {
+            return res.send(EMPTY_TILE_BUFFER).end();
+        }
+>>>>>>> 3999160 (optimizing vector tile performance)
 
         res.send(tile.tile_data);
-
+        
     } catch (err) {
         console.error(err);
         res.status(500).send("Tile error");

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -367,14 +367,13 @@ router.post('/api/analytics/map-creation', (req, res) => {
 });
 
 // API route to fetch roads within a bounding box
-router.get('/api/roads', (req, res) => {
+router.get('/api/roads', validationParam.validateBBox, (req, res) => {
     const { xmin, xmax, ymin, ymax } = req.query;
 
     // Validate parameters
     if (!xmin || !xmax || !ymin || !ymax) {
         return res.status(400).json({ error: "Missing required parameters: xmin, xmax, ymin, ymax" });
     }
-
     try {
         // Convert to numbers
         const bbox = {

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -53,7 +53,7 @@ router.get('/tiles/:layer/:z/:x/:y.png', validationParam.validateTiles, (req, re
     }
 });
 
-router.get('/tiles/contours/:z/:x/:y.pbf', validationParam.validateContours, (req, res) => {
+router.get('/tiles/contours/:z/:x/:y.pbf', validationParam.validateVectorTiles, (req, res) => {
     if (!Object.hasOwn(mbtilesDb, 'contours') || !mbtilesDb['contours']) {
         return res.status(404).end();
     }
@@ -366,58 +366,36 @@ router.post('/api/analytics/map-creation', (req, res) => {
     }
 });
 
-// API route to fetch roads within a bounding box
-router.get('/api/roads', validationParam.validateBBox, (req, res) => {
-    const { xmin, xmax, ymin, ymax } = req.query;
+router.get('/tiles/roads/:z/:x/:y.pbf', validationParam.validateVectorTiles, (req, res) => {
 
-    // Validate parameters
-    if (!xmin || !xmax || !ymin || !ymax) {
-        return res.status(400).json({ error: "Missing required parameters: xmin, xmax, ymin, ymax" });
-    }
+    const z = Number(req.params.z);
+    const x = Number(req.params.x);
+    const y = Number(req.params.y);
+    const flippedY = (1 << z) - 1 - y;
+
     try {
-        // Convert to numbers
-        const bbox = {
-            xmin: parseFloat(xmin),
-            xmax: parseFloat(xmax),
-            ymin: parseFloat(ymin),
-            ymax: parseFloat(ymax)
-        };
+        const stmt = mbtilesDb['roads'].prepare(`
+            SELECT tile_data FROM tiles
+            WHERE zoom_level = ?
+            AND tile_column = ?
+            AND tile_row = ?
+        `);
 
-        // Validate bbox values
-        if (isNaN(bbox.xmin) || isNaN(bbox.xmax) || isNaN(bbox.ymin) || isNaN(bbox.ymax)) {
-            return res.status(400).json({ error: "Invalid bbox values - must be numeric" });
+        const tile = stmt.get(z, x, flippedY);
+        if (!tile) {
+            return res.status(204).end();
         }
 
-        const query = `
-            SELECT name, road_class, road_type, geom_to_wkt, minx, miny, maxx, maxy
-            FROM main_afg_roads
-            WHERE
-                minx <= ? AND
-                maxx >= ? AND
-                miny <= ? AND
-                maxy >= ?
-        `;
+        res.setHeader('Content-Type', 'application/x-protobuf');
+        res.setHeader('Content-Encoding', 'gzip');
 
-        const roads = db.prepare(query).all(bbox.xmax, bbox.xmin, bbox.ymax, bbox.ymin);
-        console.log(`Fetched ${roads.length} roads intersecting bbox (${bbox.xmin}, ${bbox.ymin}, ${bbox.xmax}, ${bbox.ymax})`);
-        const geojson = {
-            type: "FeatureCollection",
-            features: roads.map(r => ({
-                type: "Feature",
-                properties: {
-                    name: r.name,
-                    type: r.road_type,
-                    class: r.road_class
-                },
-                geometry: wellknown.parse(r.geom_to_wkt)
-            }))
-        };
+        res.send(tile.tile_data);
 
-        res.json(geojson);
     } catch (err) {
         console.error(err);
-        res.status(500).send("Database Error");
+        res.status(500).send("Tile error");
     }
 });
+
 
 module.exports = router;

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -393,14 +393,11 @@ router.get('/tiles/roads/:z/:x/:y.pbf', validationParam.validateVectorTiles, (re
         
         res.setHeader('Content-Type', 'application/x-protobuf');
         res.setHeader('Content-Encoding', 'gzip');
-<<<<<<< HEAD
-=======
         res.setHeader('Cache-Control', 'public, max-age=1209600'); // Cache for 2 weeks
-        
+
         if (!tile) {
             return res.send(EMPTY_TILE_BUFFER).end();
         }
->>>>>>> 3999160 (optimizing vector tile performance)
 
         res.send(tile.tile_data);
         

--- a/routes/validationParams.js
+++ b/routes/validationParams.js
@@ -16,7 +16,7 @@ const validateTiles = [
     validateRequest
 ];
 
-const validateContours = [
+const validateVectorTiles = [
     param(['z', 'x', 'y']).isInt({ min: 0 }).toInt().withMessage('Coordinate must be a non-negative integer'),
     validateRequest
 ];
@@ -118,34 +118,14 @@ const validateMapCreationAnalytics = [
     validateRequest
 ];
 
-const validateBBox = [
-    query(['xmin', 'xmax'])
-        .isFloat({ min: 55, max: 80 })
-        .withMessage('xmin and xmax must be within Afghanistan longitude range'),
-    query(['ymin', 'ymax'])
-        .isFloat({ min: 25, max: 42 })
-        .withMessage('ymin and ymax must be within Afghanistan latitude range'),
-    query().custom((_, { req }) => {
-        const { xmin, xmax, ymin, ymax } = req.query;
-        if (parseFloat(xmin) >= parseFloat(xmax)) {
-            throw new Error('xmin must be less than xmax');
-        }
-        if (parseFloat(ymin) >= parseFloat(ymax)) {
-            throw new Error('ymin must be less than ymax');
-        }
-        return true;
-    })
-];
-
 // Export them exactly like your example
 module.exports = {
     validateTiles,
-    validateContours,
+    validateVectorTiles,
     validateProvinces,
     validateDistricts,
     validateCommunities,
     validateSearchName,
     validateSearchCode,
-    validateMapCreationAnalytics,
-    validateBBox
+    validateMapCreationAnalytics
 };

--- a/routes/validationParams.js
+++ b/routes/validationParams.js
@@ -118,6 +118,25 @@ const validateMapCreationAnalytics = [
     validateRequest
 ];
 
+const validateBBox = [
+    query(['xmin', 'xmax'])
+        .isFloat({ min: 55, max: 80 })
+        .withMessage('xmin and xmax must be within Afghanistan longitude range'),
+    query(['ymin', 'ymax'])
+        .isFloat({ min: 25, max: 42 })
+        .withMessage('ymin and ymax must be within Afghanistan latitude range'),
+    query().custom((_, { req }) => {
+        const { xmin, xmax, ymin, ymax } = req.query;
+        if (parseFloat(xmin) >= parseFloat(xmax)) {
+            throw new Error('xmin must be less than xmax');
+        }
+        if (parseFloat(ymin) >= parseFloat(ymax)) {
+            throw new Error('ymin must be less than ymax');
+        }
+        return true;
+    })
+];
+
 // Export them exactly like your example
 module.exports = {
     validateTiles,
@@ -127,5 +146,6 @@ module.exports = {
     validateCommunities,
     validateSearchName,
     validateSearchCode,
-    validateMapCreationAnalytics
+    validateMapCreationAnalytics,
+    validateBBox
 };

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const corsOptions = {
 // 3. Rate Limiting: Prevent scraping and DoS attacks
 const tileLimiter = rateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute window
-    max: 600, // Limit each IP to 600 tile requests per minute
+    max: 6000, // Limit each IP to 600 tile requests per minute
     message: "Too many tiles requested, please try again later."
 });
 
@@ -35,6 +35,7 @@ const apiLimiter = rateLimit({
     max: 200, // Limit each IP to 200 API requests per 5 minutes
     message: "Too many API requests, please try again later."
 });
+
 
 // Nginx parameter for reverse proxy
 app.set('trust proxy', 1);

--- a/views/index.html
+++ b/views/index.html
@@ -290,7 +290,7 @@
     <script src="https://unpkg.com/georaster"></script>
     <script src="https://unpkg.com/georaster-layer-for-leaflet"></script>
     <script src="https://unpkg.com/leaflet.vectorgrid/dist/Leaflet.VectorGrid.bundled.js"></script>
-
+    <script src="https://unpkg.com/leaflet-textpath"></script>
 
     <!-- Vendored export libraries (local — offline-safe) -->
     <script src="/js/html-to-image.min.js"></script>

--- a/views/index.html
+++ b/views/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/css/styles.css" />
     <link rel="stylesheet" href="/css/mbtiles-filters.css" />
     <link rel="stylesheet" href="/css/suggestions.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
 
     <link rel="icon" href="/assets/img/globe-icon.png" type="image/png">
 </head>
@@ -291,6 +292,8 @@
     <script src="https://unpkg.com/georaster-layer-for-leaflet"></script>
     <script src="https://unpkg.com/leaflet.vectorgrid/dist/Leaflet.VectorGrid.bundled.js"></script>
     <script src="https://unpkg.com/leaflet-textpath"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js"></script>
 
     <!-- Vendored export libraries (local — offline-safe) -->
     <script src="/js/html-to-image.min.js"></script>


### PR DESCRIPTION
**Summary**
- Add road vector tile layer with color-coded styling (primary, secondary, minor roads)
- Add draw/measurement tools (distance, area, radius, coordinates) via Leaflet.Draw + Turf.js
- Optimize vector tile performance (updateWhenIdle, keepBuffer, 2-week cache headers)
- Add zoom-aware context layer controls (auto-disable below minZoom)
- Rename contour validator to shared validateVectorTiles
- Increase tile rate limit from 600 to 6000/min for vector tile workloads

 **Notes**
- Analytics system preserved during rebase (was lost in original branch due to forking before analytics commit landed on main)
- Roads route still needs a null-guard for when mbtiles file is absent — will fix in follow-up
- Leaflet.Draw and Turf.js loaded from CDN (consistent with existing pattern)

